### PR TITLE
Ezra/warning banner

### DIFF
--- a/frontend/assets/scss/_theme.scss
+++ b/frontend/assets/scss/_theme.scss
@@ -4,7 +4,7 @@ $primary-green-color: hsl(86, 84%, 34%);
 $primary-purple-color: hsl(265, 60%, 44%);
 
 
-$light-red-color: hsl(11, 86%, 69%);
+$light-red-color: hsl(11, 86%, 80%);
 $light-yellow-color: hsl(57, 81%, 69%);
 $light-green-color: hsl(95, 76%, 58%);
 $light-purple-color: hsl(265, 76%, 64%);

--- a/frontend/assets/scss/_theme.scss
+++ b/frontend/assets/scss/_theme.scss
@@ -21,27 +21,24 @@ $gray-color: hsl(208, 10%, 75%);
 $black-color: hsl(210, 6%, 26%);
 
 
-.success {
-    background-color: $light-green-color;
-    border-color: $dark-green-color;
-    color: $primary-green-color;
+@mixin notification-theme($background-color, $border-color, $text-color) {
+    background-color: $background-color;
+    border-color: $border-color;
+    color: $text-color;
 }
 
-.info {
-    background-color: $white-color;
-    border-color: $gray-color;
-    color: $black-color;
+.notify-success {
+    @include notification-theme($light-green-color, $dark-green-color, $primary-green-color);
 }
 
-.warning {
-    background-color: $light-yellow-color;
-    border-color: $dark-yellow-color;
-    color: $dark-orange-color;
+.notify-info {
+    @include notification-theme($white-color, $gray-color, $black-color);
 }
 
+.notify-warning {
+    @include notification-theme($light-yellow-color, $dark-yellow-color, $primary-orange-color);
+}
 
-.error {
-    background-color: $light-red-color;
-    border-color: $dark-red-color;
-    color: $primary-red-color;
+.notify-error {
+    @include notification-theme($light-red-color, $dark-red-color, $primary-red-color);
 }

--- a/frontend/assets/scss/_theme.scss
+++ b/frontend/assets/scss/_theme.scss
@@ -1,20 +1,47 @@
 $primary-red-color: hsl(11, 93%, 43%);
 $primary-orange-color: hsl(39, 94%, 40%);
-$primary-yellow-color: hsl(57, 81%, 69%);
-$primary-green-color: hsl(86, 96%, 22%);
+$primary-green-color: hsl(86, 84%, 34%);
 $primary-purple-color: hsl(265, 60%, 44%);
 
+
+$light-red-color: hsl(11, 86%, 69%);
+$light-yellow-color: hsl(57, 81%, 69%);
+$light-green-color: hsl(95, 76%, 58%);
 $light-purple-color: hsl(265, 76%, 64%);
 
-$dark-red-color: hsl(11, 86%, 32%);
+
+$dark-red-color: hsl(5, 54%, 32%);
 $dark-orange-color: hsl(39, 87%, 32%);
-$dark-green-color: hsl(137, 55%, 17%);
+$dark-yellow-color: hsl(57, 57%, 45%);
+$dark-green-color: hsl(119, 35%, 37%);
 $dark-purple-color: hsl(259, 67%, 26%);
 
 $white-color: hsl(210, 17%, 98%);
 $gray-color: hsl(208, 10%, 75%);
 $black-color: hsl(210, 6%, 26%);
 
-$success-color: $primary-green-color;
-$warning-color: $primary-yellow-color;
-$danger-color: $dark-red-color;
+
+.success {
+    background-color: $light-green-color;
+    border-color: $dark-green-color;
+    color: $primary-green-color;
+}
+
+.info {
+    background-color: $white-color;
+    border-color: $gray-color;
+    color: $black-color;
+}
+
+.warning {
+    background-color: $light-yellow-color;
+    border-color: $dark-yellow-color;
+    color: $dark-orange-color;
+}
+
+
+.error {
+    background-color: $light-red-color;
+    border-color: $dark-red-color;
+    color: $primary-red-color;
+}

--- a/frontend/components/UserForm.vue
+++ b/frontend/components/UserForm.vue
@@ -73,7 +73,7 @@ defineEmits(["submit"]);
 
 .banner {
   font-size: $medium-text-size;
-  color: $danger-color;
+  color: $dark-red-color;
 
   padding: 0.2rem;
 }

--- a/frontend/components/UserForm.vue
+++ b/frontend/components/UserForm.vue
@@ -4,7 +4,7 @@
       <h1>{{ title }}</h1>
       <span class="description" v-text="descriptionValue"></span>
     </div>
-    <span class="banner" v-text="bannerText"></span>
+    <CommonBanner v-bind="{ bannerType: BannerType.ERROR, bannerText }" />
     <fieldset class="input-group">
       <div class="control-groups">
         <slot />

--- a/frontend/components/activity/Form.vue
+++ b/frontend/components/activity/Form.vue
@@ -4,7 +4,7 @@
             <h2>{{ title }}</h2>
             <span class="description" v-text="descriptionValue"></span>
         </div>
-        <span class="banner" v-text="bannerText"></span>
+        <CommonBanner v-bind="{ bannerType: BannerType.WARNING, bannerText }" />
         <div class="input-fields-grid">
             <fieldset class="input-group">
                 <div class="control-groups">

--- a/frontend/components/common/Banner.vue
+++ b/frontend/components/common/Banner.vue
@@ -1,0 +1,21 @@
+<template>
+    <div class="banner-container" v-if="bannerText">
+        <div class="banner-area">
+            <h1 class="logo-font">{{ bannerType }}</h1>
+            <p>{{ bannerText }}</p>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { BannerType } from '@/utils/constants';
+
+defineProps<{
+    bannerType: BannerType;
+    bannerText: string;
+}>();
+
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/frontend/components/common/Banner.vue
+++ b/frontend/components/common/Banner.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="banner-container" v-if="bannerText">
-        <div class="banner-area" :class="bannerType.toLowerCase()">
+        <div class="banner-area" :class="`notify-${bannerType.toLowerCase()}`">
             <h1 class="logo-font">{{ bannerType }}</h1>
             <p>{{ bannerText }}</p>
         </div>
@@ -28,6 +28,11 @@ defineProps<{
 }
 
 .banner-area {
+    /* 
+    The banner area also adopts the theme colors toggled on the bannerType prop, 
+    e.g., notify-warning
+    See the notify-* classes in assets/scss/_theme.scss.
+    */
     padding: 1rem;
     border-radius: 0.5rem;
     border: 3px solid;
@@ -39,9 +44,6 @@ defineProps<{
         font-size: $standard-text-size;
     }
 }
-
-
-
 
 
 </style>

--- a/frontend/components/common/Banner.vue
+++ b/frontend/components/common/Banner.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="banner-container" v-if="bannerText">
-        <div class="banner-area">
+        <div class="banner-area" :class="bannerType.toLowerCase()">
             <h1 class="logo-font">{{ bannerType }}</h1>
             <p>{{ bannerText }}</p>
         </div>
@@ -18,4 +18,30 @@ defineProps<{
 </script>
 
 <style lang="scss" scoped>
+
+.banner-container {
+    display: flex;
+    justify-content: center;
+    width: 70%;
+    max-height: 20%;
+
+}
+
+.banner-area {
+    padding: 1rem;
+    border-radius: 0.5rem;
+    border: 3px solid;
+
+    h1 {
+        font-size: $medium-text-size;
+    }
+    p {
+        font-size: $standard-text-size;
+    }
+}
+
+
+
+
+
 </style>

--- a/frontend/components/common/Banner.vue
+++ b/frontend/components/common/Banner.vue
@@ -33,15 +33,15 @@ defineProps<{
     e.g., notify-warning
     See the notify-* classes in assets/scss/_theme.scss.
     */
-    padding: 1rem;
+    padding: $small-text-size;
     border-radius: 0.5rem;
     border: 3px solid;
 
     h1 {
-        font-size: $medium-text-size;
+        font-size: $standard-text-size;
     }
     p {
-        font-size: $standard-text-size;
+        font-size: $small-text-size;
     }
 }
 

--- a/frontend/pages/data.vue
+++ b/frontend/pages/data.vue
@@ -11,7 +11,7 @@
       </button>
       <div class="activity-form-toggle">
         <ActivityForm
-          :style="{ display: showActivityForm ? 'block' : 'none' }"
+          v-show="showActivityForm"
           :banner-text="bannerError"
           title="Create Data Series"
           button-title="Create"

--- a/frontend/stores/user.ts
+++ b/frontend/stores/user.ts
@@ -1,4 +1,4 @@
-import type { UserResponseObject } from "~/utils/interfaces/response-objects";
+import type { UserResponseObject } from "@/utils/interfaces/response-objects";
 
 export const useUserStore = defineStore("userStore", {
   state: () => ({

--- a/frontend/utils/constants/index.ts
+++ b/frontend/utils/constants/index.ts
@@ -1,0 +1,2 @@
+export * from "./routes";
+export * from "./view-constants";

--- a/frontend/utils/constants/view-constants.ts
+++ b/frontend/utils/constants/view-constants.ts
@@ -1,0 +1,6 @@
+export enum BannerType {
+  SUCCESS = "Success",
+  INFO = "Info",
+  WARNING = "Warning",
+  ERROR = "Error",
+};

--- a/frontend/utils/index.ts
+++ b/frontend/utils/index.ts
@@ -1,3 +1,2 @@
-export * from "./constants/routes";
-export * from "./interfaces/response-objects";
-export * from "./interfaces/state-objects";
+export * from "./constants";
+export * from "./interfaces";

--- a/frontend/utils/interfaces/index.ts
+++ b/frontend/utils/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from "./response-objects";
+export * from "./state-objects";


### PR DESCRIPTION
replaces the span with a reusable Banner component that can popup as needed, with stylings based on a `BannerType` enum

![Screenshot 2024-03-25 at 2 04 22 AM](https://github.com/TresTres/sapin-sapin/assets/14167519/47cb4ceb-e3c8-43c0-995b-f0ba0c6cbd8a)
![Screenshot 2024-03-25 at 2 04 46 AM](https://github.com/TresTres/sapin-sapin/assets/14167519/c2ed3ff0-3147-4f98-9c7e-a40c9927c335)

It could use a better design, but it will do for now